### PR TITLE
chore: update to jquery-ui-rails 7

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -2,3 +2,5 @@ source "http://rubygems.org"
 
 # Specify your gem's dependencies in jquery.fileupload-rails.gemspec
 gemspec
+
+gem 'jquery-ui-rails', github: 'jquery-ui-rails/jquery-ui-rails', tag: 'v7.0.0'

--- a/jquery.fileupload-rails.gemspec
+++ b/jquery.fileupload-rails.gemspec
@@ -13,5 +13,5 @@ Gem::Specification.new do |s|
   s.files       = File.read('Manifest.txt').split("\n")
 
   s.add_dependency 'railties', '>= 3.1'
-  s.add_dependency 'jquery-ui-rails', '~> 6.0'
+  s.add_dependency 'jquery-ui-rails', '~> 7.0'
 end


### PR DESCRIPTION
The new version is not on rubygems, so it is pulled in from Github. This resolves a security vulnerability with the older version.